### PR TITLE
use identifier `daxstudio.daxstudio` in winget

### DIFF
--- a/docs/installation/winget.md
+++ b/docs/installation/winget.md
@@ -7,7 +7,7 @@ DAX Studio can be installed and updated using [winget](https://learn.microsoft.c
 # Installing for all users 
 
 ```
-winget install daxstudio --scope machine
+winget install daxstudio.daxstudio --scope machine
 ```
 
 ::: note
@@ -17,17 +17,17 @@ Installing for All users requires admin rights. You need to install for All user
 # Installing for current user
 
 ```
-winget install daxstudio 
+winget install daxstudio.daxstudio 
 ```
 
 # Updating
 
 ```
-winget upgrade daxstudio
+winget upgrade daxstudio.daxstudio
 ```
 
 # Uninstalling
 
 ```
-winget uninstall daxstudio
+winget uninstall daxstudio.daxstudio
 ```


### PR DESCRIPTION
The current commands in the documentation don't work for me, so I needed to use an ID. I guess it will be useful for others.

p.s. I didn't use Dax Studio for years, as I wasn't using Windows; however, touching this piece of software again is so pleasant! Dax Studio is solid and awesome! Thank you!